### PR TITLE
Prompt user for RAM size in QEMU command

### DIFF
--- a/win10
+++ b/win10
@@ -2,4 +2,7 @@
 export HOME="/data/data/com.termux/files/home"
 cd ~/base_arm64/khanh 2> /dev/null
 echo "VNC Server: 127.0.0.1:5901"
-qemu-system-aarch64 -M virt -cpu cortex-a53 -smp 4 --accel tcg,thread=multi -m 1024 -bios BIOS.img -device VGA -device nec-usb-xhci -device usb-kbd -device usb-mouse -device usb-storage,drive=boot -drive if=none,id=boot,file="base_arm64.qcow2" -vnc :1
+
+read -p "Enter RAM size in MB (e.g., 2048): " ram
+
+qemu-system-aarch64 -M virt -cpu cortex-a53 -smp 4 --accel tcg,thread=multi -m $ram -bios BIOS.img -device VGA -device nec-usb-xhci -device usb-kbd -device usb-mouse -device usb-storage,drive=boot -drive if=none,id=boot,file="base_arm64.qcow2" -vnc :1

--- a/win10
+++ b/win10
@@ -3,6 +3,20 @@ export HOME="/data/data/com.termux/files/home"
 cd ~/base_arm64/khanh 2> /dev/null
 echo "VNC Server: 127.0.0.1:5901"
 
-read -p "Enter RAM size in MB (e.g., 2048): " ram
+read -p "Enter RAM size in MB [default: 1536]: " ram
+ram=${ram:-1536}
 
-qemu-system-aarch64 -M virt -cpu cortex-a53 -smp 4 --accel tcg,thread=multi -m $ram -bios BIOS.img -device VGA -device nec-usb-xhci -device usb-kbd -device usb-mouse -device usb-storage,drive=boot -drive if=none,id=boot,file="base_arm64.qcow2" -vnc :1
+qemu-system-aarch64 \
+  -M virt \
+  -cpu cortex-a53 \
+  -smp 4 \
+  --accel tcg,thread=multi \
+  -m "$ram" \
+  -bios BIOS.img \
+  -device VGA \
+  -device nec-usb-xhci \
+  -device usb-kbd \
+  -device usb-mouse \
+  -device usb-storage,drive=boot \
+  -drive if=none,id=boot,file="base_arm64.qcow2" \
+  -vnc :1


### PR DESCRIPTION
Added prompt for user to enter RAM size for QEMU.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The Windows 10 launch script now prompts for the desired RAM size (in MB) at runtime, with a default of 1536 MB.
  * The virtual machine launch now uses the selected RAM value instead of a hardcoded default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->